### PR TITLE
improv(startup): add healthcheck on mariadb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
       - MARIADB_USER=bn_wordpress
       - MARIADB_DATABASE=bitnami_wordpress
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
   wordpress:
     image: docker.io/bitnami/wordpress:6
     ports:
@@ -17,7 +21,8 @@ services:
     volumes:
       - 'wordpress_data:/bitnami/wordpress'
     depends_on:
-      - mariadb
+      mariadb:
+        condition: service_healthy
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
**Description of the change**

It adds health checks to the mariadb container and ensures the wordpress container waits for it before startup.

**Benefits**

Avoid racing issues when the wordpress container starts before the mariadb one is ready.
